### PR TITLE
allow-hotplug instead of auto for eth0

### DIFF
--- a/simpleimage/make_rootfs.sh
+++ b/simpleimage/make_rootfs.sh
@@ -300,7 +300,7 @@ EOF
 		chmod +x "$DEST/second-phase"
 		do_chroot /second-phase
 		cat > "$DEST/etc/network/interfaces.d/eth0" <<EOF
-auto eth0
+allow-hotplug eth0
 iface eth0 inet dhcp
 EOF
 		cat > "$DEST/etc/hostname" <<EOF


### PR DESCRIPTION
This is not the appropriate setting for the pinebook, as it does not have a eth0 connection! It causes an error in the networking.service log instead of clean exit. It will additionally delay boot on pine64s/sopines without a ethernet cable plugged in. 

This is the expected output (http://sprunge.us/NVjZ) as opposed to the output met (http://sprunge.us/EHFW).

Expected output (when changed to allow-hotplug):
```
-- Logs begin at Sun 2017-06-18 18:41:28 AEST, end at Sun 2017-06-18 18:43:34 AEST. --
Jun 18 18:42:00 pinebook systemd[1]: Starting Raise network interfaces...
Jun 18 18:42:01 pinebook systemd[1]: Started Raise network interfaces.
```

Output per default (auto):
```
-- Logs begin at Sun 2017-06-18 18:39:08 AEST, end at Sun 2017-06-18 18:40:41 AEST. --
Jun 18 18:39:10 pinebook systemd[1]: Starting Raise network interfaces...
Jun 18 18:39:12 pinebook dhclient[668]: Internet Systems Consortium DHCP Client 4.3.3
Jun 18 18:39:12 pinebook dhclient[668]: Copyright 2004-2015 Internet Systems Consortium.
Jun 18 18:39:12 pinebook ifup[596]: Internet Systems Consortium DHCP Client 4.3.3
Jun 18 18:39:12 pinebook ifup[596]: Copyright 2004-2015 Internet Systems Consortium.
Jun 18 18:39:12 pinebook ifup[596]: All rights reserved.
Jun 18 18:39:12 pinebook ifup[596]: For info, please visit https://www.isc.org/software/dhcp/
Jun 18 18:39:12 pinebook dhclient[668]: All rights reserved.
Jun 18 18:39:12 pinebook dhclient[668]: For info, please visit https://www.isc.org/software/dhcp/
Jun 18 18:39:12 pinebook dhclient[668]: 
Jun 18 18:39:13 pinebook ifup[596]: Cannot find device "eth0"
Jun 18 18:39:13 pinebook dhclient[668]: Error getting hardware address for "eth0": No such device
Jun 18 18:39:13 pinebook ifup[596]: Error getting hardware address for "eth0": No such device
Jun 18 18:39:13 pinebook ifup[596]: If you think you have received this message due to a bug rather
Jun 18 18:39:13 pinebook ifup[596]: than a configuration issue please read the section on submitting
Jun 18 18:39:13 pinebook ifup[596]: bugs on either our web page at www.isc.org or in the README file
Jun 18 18:39:13 pinebook ifup[596]: before submitting a bug.  These pages explain the proper
Jun 18 18:39:13 pinebook ifup[596]: process and the information we find helpful for debugging..
Jun 18 18:39:13 pinebook ifup[596]: exiting.
Jun 18 18:39:13 pinebook ifup[596]: Failed to bring up eth0.
Jun 18 18:39:13 pinebook systemd[1]: networking.service: Main process exited, code=exited, status=1/FAILURE
Jun 18 18:39:13 pinebook systemd[1]: Failed to start Raise network interfaces.
Jun 18 18:39:13 pinebook systemd[1]: networking.service: Unit entered failed state.
Jun 18 18:39:13 pinebook systemd[1]: networking.service: Failed with result 'exit-code'.

```

