### PR TITLE
Jenkins conditional release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ properties([
     string(defaultValue: 'ayufan-pine64', description: 'GitHub username or organization', name: 'GITHUB_USER'),
     string(defaultValue: 'build-pine64-image', description: 'GitHub repository', name: 'GITHUB_REPO'),
     booleanParam(defaultValue: true, description: 'Whether to upload to Github for release or not', name: 'GITHUB_UPLOAD'),
-    string(devaultValue: 'all', description: 'What build type to target', name: 'MAKE_TARGET'),
+    string(devaultValue: 'all', description: 'What makefile build type to target', name: 'MAKE_TARGET'),
   ])
 ])
 */
@@ -86,7 +86,7 @@ node('docker && linux-build') {
           }
           else
           {
-             echo 'Flagged as non-release build'
+             echo 'Flagged as no upload release job'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,8 @@ properties([
     booleanParam(defaultValue: false, description: 'If build should be marked as pre-release', name: 'PRERELEASE'),
     string(defaultValue: 'ayufan-pine64', description: 'GitHub username or organization', name: 'GITHUB_USER'),
     string(defaultValue: 'build-pine64-image', description: 'GitHub repository', name: 'GITHUB_REPO'),
-    booleanParam(defaultValue: true, descriptoin: 'Whether to upload to Github for release or not', name: 'GITHUB_RELEASE'),
+    booleanParam(defaultValue: true, description: 'Whether to upload to Github for release or not', name: 'GITHUB_UPLOAD'),
+    string(devaultValue: 'all', description: 'What build type to target', name: 'MAKE_TARGET'),
   ])
 ])
 */
@@ -37,7 +38,7 @@ node('docker && linux-build') {
             sh '''#!/bin/bash
               set +xe
               export CCACHE_DIR=$WORKSPACE/ccache
-              make -j4
+              make -j4 $MAKE_TARGET
             '''
         }
   

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ properties([
     booleanParam(defaultValue: false, description: 'If build should be marked as pre-release', name: 'PRERELEASE'),
     string(defaultValue: 'ayufan-pine64', description: 'GitHub username or organization', name: 'GITHUB_USER'),
     string(defaultValue: 'build-pine64-image', description: 'GitHub repository', name: 'GITHUB_REPO'),
+    booleanParam(defaultValue: true, descriptoin: 'Whether to upload to Github for release or not', name: 'GITHUB_RELEASE'),
   ])
 ])
 */
@@ -48,6 +49,7 @@ node('docker && linux-build') {
           "GITHUB_REPO=$GITHUB_REPO"
         ]) {
           stage 'Release'
+          if (GITHUB_UPLOAD == true) { 
           sh '''#!/bin/bash
             set -xe
             shopt -s nullglob
@@ -80,6 +82,11 @@ node('docker && linux-build') {
                 --description "${CHANGES}\n\n${BUILD_URL}"
             fi
           '''
+          }
+          else
+          {
+             echo 'Flagged as non-release build'
+          }
         }
       }
     }


### PR DESCRIPTION
Would you consider adding this to your Jenkinsfile. Allows for specific make targets to be built, and for github uploads to be skipped. By adding two more parameters and setting the defaults as indicated it will behave exactly as it does now. I find it useful for when wanting just a minimal pinebook build, or xenial-mate-pinebook build, without having to build all the others. 

If you're happy with this I'll push another PR for the rock64 build script also, as I've done the same for it.