### PR TITLE
Changing the default wallpaper for MATE

### DIFF
--- a/package/root/usr/local/sbin/install_desktop.sh
+++ b/package/root/usr/local/sbin/install_desktop.sh
@@ -93,7 +93,7 @@ case $DESKTOP in
 	mate)
 		# Change default wallpaper
 		dpkg-divert --divert /usr/share/backgrounds/ubuntu-mate-common/Ubuntu-Mate-Cold-stock.jpg --rename /usr/share/backgrounds/ubuntu-mate-common/Ubuntu-Mate-Cold.jpg
-		ln /usr/share/backgrounds/ubuntu-mate-pinebook/Pinebook-Wallpaper-6.jpg /usr/share/backgrounds/ubuntu-mate-common/Ubuntu-Mate-Cold.jpg
+		ln -s /usr/share/backgrounds/ubuntu-mate-pinebook/Pinebook-Wallpaper-6.jpg /usr/share/backgrounds/ubuntu-mate-common/Ubuntu-Mate-Cold.jpg
 		;;
 
 	i3|i3wm)

--- a/package/root/usr/local/sbin/install_desktop.sh
+++ b/package/root/usr/local/sbin/install_desktop.sh
@@ -90,6 +90,12 @@ fi
 
 # Desktop dependent post installation.
 case $DESKTOP in
+	mate)
+		# Change default wallpaper
+		dpkg-divert --divert /usr/share/backgrounds/ubuntu-mate-common/Ubuntu-Mate-Cold-stock.jpg --rename /usr/share/backgrounds/ubuntu-mate-common/Ubuntu-Mate-Cold.jpg
+		ln /usr/share/backgrounds/ubuntu-mate-pinebook/Pinebook-Wallpaper-6.jpg /usr/share/backgrounds/ubuntu-mate-common/Ubuntu-Mate-Cold.jpg
+		;;
+
 	i3|i3wm)
 		if [ ! -d /usr/share/slim/themes/pine64 ]; then
 			cp -ra /usr/share/slim/themes/default /usr/share/slim/themes/pine64


### PR DESCRIPTION
Hacky fix that diverts the default Ubuntu Mate wallapper and links to a Pinebook one. Tested to work on a local rebuild of 0.5.5. As it's a dpkg-diversion, it will survive package updates.

Resolves #9 