### PR TITLE
Changes to enable internal mic by default

### DIFF
--- a/package/root/var/lib/alsa/asound.state
+++ b/package/root/var/lib/alsa/asound.state
@@ -2,8 +2,8 @@ state.audiocodec {
 	control.1 {
 		iface MIXER
 		name 'AIF1 ADC timeslot 0 volume'
-		value.0 0
-		value.1 0
+		value.0 228
+		value.1 228
 		comment {
 			access 'read write'
 			type INTEGER
@@ -11,15 +11,15 @@ state.audiocodec {
 			range '0 - 255'
 			dbmin -11925
 			dbmax 7200
-			dbvalue.0 -11925
-			dbvalue.1 -11925
+			dbvalue.0 5175
+			dbvalue.1 5175
 		}
 	}
 	control.2 {
 		iface MIXER
 		name 'AIF1 ADC timeslot 1 volume'
-		value.0 0
-		value.1 0
+		value.0 225
+		value.1 225
 		comment {
 			access 'read write'
 			type INTEGER
@@ -27,8 +27,8 @@ state.audiocodec {
 			range '0 - 255'
 			dbmin -11925
 			dbmax 7200
-			dbvalue.0 -11925
-			dbvalue.1 -11925
+			dbvalue.0 4950
+			dbvalue.1 4950
 		}
 	}
 	control.3 {
@@ -66,8 +66,8 @@ state.audiocodec {
 	control.5 {
 		iface MIXER
 		name 'AIF1 ADC timeslot 0 mixer gain'
-		value.0 0
-		value.1 0
+		value.0 14
+		value.1 14
 		comment {
 			access 'read write'
 			type INTEGER
@@ -75,15 +75,15 @@ state.audiocodec {
 			range '0 - 15'
 			dbmin -600
 			dbmax 8400
-			dbvalue.0 -600
-			dbvalue.1 -600
+			dbvalue.0 7800
+			dbvalue.1 7800
 		}
 	}
 	control.6 {
 		iface MIXER
 		name 'AIF1 ADC timeslot 1 mixer gain'
-		value.0 0
-		value.1 0
+		value.0 3
+		value.1 3
 		comment {
 			access 'read write'
 			type INTEGER
@@ -91,8 +91,8 @@ state.audiocodec {
 			range '0 - 3'
 			dbmin -600
 			dbmax 1200
-			dbvalue.0 -600
-			dbvalue.1 -600
+			dbvalue.0 1200
+			dbvalue.1 1200
 		}
 	}
 	control.7 {
@@ -146,8 +146,8 @@ state.audiocodec {
 	control.10 {
 		iface MIXER
 		name 'ADC volume'
-		value.0 0
-		value.1 0
+		value.0 153
+		value.1 153
 		comment {
 			access 'read write'
 			type INTEGER
@@ -155,8 +155,8 @@ state.audiocodec {
 			range '0 - 255'
 			dbmin -11925
 			dbmax 7200
-			dbvalue.0 -11925
-			dbvalue.1 -11925
+			dbvalue.0 -450
+			dbvalue.1 -450
 		}
 	}
 	control.11 {
@@ -320,7 +320,7 @@ state.audiocodec {
 	control.22 {
 		iface MIXER
 		name 'ADC input gain control'
-		value 0
+		value 4
 		comment {
 			access 'read write'
 			type INTEGER
@@ -328,7 +328,7 @@ state.audiocodec {
 			range '0 - 7'
 			dbmin -450
 			dbmax 600
-			dbvalue.0 -450
+			dbvalue.0 150
 		}
 	}
 	control.23 {
@@ -368,7 +368,7 @@ state.audiocodec {
 	control.26 {
 		iface MIXER
 		name 'Phoneout Mixer MIC1 boost Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -378,7 +378,7 @@ state.audiocodec {
 	control.27 {
 		iface MIXER
 		name 'Phoneout Mixer MIC2 boost Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -408,7 +408,7 @@ state.audiocodec {
 	control.30 {
 		iface MIXER
 		name 'ADCR Mux'
-		value DMIC
+		value ADC
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -420,7 +420,7 @@ state.audiocodec {
 	control.31 {
 		iface MIXER
 		name 'ADCL Mux'
-		value DMIC
+		value ADC
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -454,7 +454,7 @@ state.audiocodec {
 	control.34 {
 		iface MIXER
 		name 'RADC input Mixer MIC2 boost Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -514,7 +514,7 @@ state.audiocodec {
 	control.40 {
 		iface MIXER
 		name 'LADC input Mixer MIC1 boost Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -524,7 +524,7 @@ state.audiocodec {
 	control.41 {
 		iface MIXER
 		name 'LADC input Mixer MIC2 boost Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -1074,7 +1074,7 @@ state.audiocodec {
 	control.93 {
 		iface MIXER
 		name 'AIF1 AD0R Mixer ADCR Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -1114,7 +1114,7 @@ state.audiocodec {
 	control.97 {
 		iface MIXER
 		name 'AIF1 AD0L Mixer ADCL Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN
@@ -1337,19 +1337,6 @@ state.sndhdmi {
 			item.11 DTS_HD
 			item.12 MAT
 			item.13 WMAPRO
-		}
-	}
-	control.2 {
-		iface MIXER
-		name 'sunxi daudio audio hub mode'
-		value hub_disable
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 null
-			item.1 hub_disable
-			item.2 hub_enable
 		}
 	}
 }


### PR DESCRIPTION
Changes to asound.state to enable internal mic on Pinebook by default. Shows the changes not visible on #19. Will submit a second PR once this is merged as line endings on the original file are wrong... they are DOS formatted, not UNIX formatted, hence why github wasn't able to show the differences. ;)