### PR TITLE
Audio group permission missing

### DIFF
--- a/simpleimage/make_rootfs.sh
+++ b/simpleimage/make_rootfs.sh
@@ -187,7 +187,7 @@ apt-get -y update
 adduser --gecos $DEBUSER --disabled-login $DEBUSER --uid 1000
 chown -R 1000:1000 /home/$DEBUSER
 echo "$DEBUSER:$DEBUSERPW" | chpasswd
-usermod -a -G sudo,adm,input,video,plugdev $DEBUSER
+usermod -a -G sudo,adm,audio,input,video,plugdev $DEBUSER
 apt-get -y autoremove
 apt-get clean
 EOF


### PR DESCRIPTION
Without this, the pine64 user will not have audio access!

This is the root of the audio missing issue from a clean install of at least version 0.7.1 onwards of the ubuntu mate pinebook image ;)