### PR TITLE
added udev rules to allow systemd-logind to monitor for power-events

### DIFF
--- a/package/root/etc/udev/rules.d/70-power-switch.rules
+++ b/package/root/etc/udev/rules.d/70-power-switch.rules
@@ -1,0 +1,11 @@
+# Match the special power key input/event
+ACTION=="add", SUBSYSTEM=="input", ATTRS{name}=="axp81x-supplyer", TAG+="power-switch"
+
+# Match the touchpad and special/blue Fn-keys
+# Also matches the normal keyboard but it fires no power-switch relevant events
+# There appears to be little difference between the keyboard/mouse devices, only:
+# ID_INPUT_MOUSE=1 vs ID_INPUT_KEYBOARD=1
+ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor}=="258a", ATTRS{idProduct}=="000c", TAG+="power-switch"
+
+# Match the lid/hall sensor
+ACTION=="add", SUBSYSTEM=="input", ATTRS{name}=="hall", TAG+="power-switch"


### PR DESCRIPTION
Addresses issue #59 

Adds udev rule for power key so that `/etc/systemd/logind.conf` can use `HandlePowerKey`
Adds udev rule for sleep key so that `/etc/systemd/logind.conf`can use `HandleSuspendKey`
Adds udev rule for hall sensor/lid switch so that `/etc/systemd/logind.conf` can use `HandleLidSwitch`.