### PR TITLE
Enable NetworkManager/wifi access to normal users(non sudo)

### DIFF
--- a/NetworkManager.conf
+++ b/NetworkManager.conf
@@ -1,0 +1,5 @@
+[main]
+plugins=ifupdown,keyfile
+
+[ifupdown]
+managed=true

--- a/package/root/etc/NetworkManager/NetworkManager.conf
+++ b/package/root/etc/NetworkManager/NetworkManager.conf
@@ -1,0 +1,5 @@
+[main]
+plugins=ifupdown,keyfile
+
+[ifupdown]
+managed=true

--- a/package/root/usr/local/sbin/install_desktop.sh
+++ b/package/root/usr/local/sbin/install_desktop.sh
@@ -47,6 +47,7 @@ PACKAGES+=(
 	rxvt-unicode-lite
 	suckless-tools
 	network-manager
+	network-manager-gnome
 	pulseaudio
 )
 

--- a/package/root/var/lib/polkit-1/10-vendor.d/org.freedesktop.NetworkManager.pkla
+++ b/package/root/var/lib/polkit-1/10-vendor.d/org.freedesktop.NetworkManager.pkla
@@ -1,0 +1,6 @@
+[Adding or changing system-wide NetworkManager connections]
+Identity=unix-group:netdev;unix-group:sudo
+Action=org.freedesktop.NetworkManager.*
+ResultAny=yes
+ResultInactive=no
+ResultActive=yes


### PR DESCRIPTION
Enable 
/etc/NetworkManager/NetworkManager.conf
`managed=true`

and 

/var/lib/polkit-1/10-vendor.d/org.freedesktop.NetworkManager.pkla

set to
```
[Adding or changing system-wide NetworkManager connections]
Identity=unix-group:netdev;unix-group:sudo
Action=org.freedesktop.NetworkManager.*
ResultAny=yes
ResultInactive=no
ResultActive=yes
```
this allows network-manager to be accessible to normal users to enable disable and connect to wifi.

install gui network-manager-gnome
/usr/local/sbin/install_desktop.sh
